### PR TITLE
Cake 2.3.0 + Enable cache script cache

### DIFF
--- a/dotnet-sdk/_templates/Dockerfile.template
+++ b/dotnet-sdk/_templates/Dockerfile.template
@@ -7,4 +7,4 @@ ENV PATH="/root/.dotnet/tools:${PATH}"
 ENV CAKE_SETTINGS_ENABLESCRIPTCACHE=true
 
 # Install cake
-RUN dotnet tool install --global Cake.Tool --version 2.2.0
+RUN dotnet tool install --global Cake.Tool --version 2.3.0

--- a/dotnet-sdk/_templates/Dockerfile.template
+++ b/dotnet-sdk/_templates/Dockerfile.template
@@ -3,5 +3,8 @@ FROM mcr.microsoft.com/dotnet/sdk:{{image_version}}
 # Add dotnet tools to path
 ENV PATH="/root/.dotnet/tools:${PATH}"
 
+# Enable cake script cache
+ENV CAKE_SETTINGS_ENABLESCRIPTCACHE=true
+
 # Install cake
 RUN dotnet tool install --global Cake.Tool --version 2.2.0


### PR DESCRIPTION
- Enable the cache script cache to speed up builds
- Upgrade cake to 2.3.0