### PR TITLE
Rollback new relic agent to 10.5.1 to fix memory leaks

### DIFF
--- a/dotnet/6.0/aspnet/Dockerfile
+++ b/dotnet/6.0/aspnet/Dockerfile
@@ -1,4 +1,4 @@
-ARG newrelic_agent_version=10.9.1
+ARG newrelic_agent_version=10.5.1
 
 # Stage to download and extract the new relic agent
 FROM alpine:latest AS builder

--- a/dotnet/6.0/runtime/Dockerfile
+++ b/dotnet/6.0/runtime/Dockerfile
@@ -1,4 +1,4 @@
-ARG newrelic_agent_version=10.9.1
+ARG newrelic_agent_version=10.5.1
 
 # Stage to download and extract the new relic agent
 FROM alpine:latest AS builder

--- a/dotnet/7.0/aspnet/Dockerfile
+++ b/dotnet/7.0/aspnet/Dockerfile
@@ -1,4 +1,4 @@
-ARG newrelic_agent_version=10.9.1
+ARG newrelic_agent_version=10.5.1
 
 # Stage to download and extract the new relic agent
 FROM alpine:latest AS builder

--- a/dotnet/7.0/runtime/Dockerfile
+++ b/dotnet/7.0/runtime/Dockerfile
@@ -1,4 +1,4 @@
-ARG newrelic_agent_version=10.9.1
+ARG newrelic_agent_version=10.5.1
 
 # Stage to download and extract the new relic agent
 FROM alpine:latest AS builder

--- a/dotnet/_templates/Dockerfile.template
+++ b/dotnet/_templates/Dockerfile.template
@@ -1,4 +1,4 @@
-ARG newrelic_agent_version=10.9.1
+ARG newrelic_agent_version=10.5.1
 
 # Stage to download and extract the new relic agent
 FROM alpine:latest AS builder


### PR DESCRIPTION
- Rollback new relic agent to 10.5.1 to fix memory leaks